### PR TITLE
refactor: use next image component

### DIFF
--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -3,6 +3,7 @@ import { format } from 'date-fns'
 import { sl } from 'date-fns/locale'
 import { sourceColors } from '@/lib/sources'
 import { MouseEvent } from 'react'
+import Image from 'next/image'
 
 interface Props {
   news: NewsItem
@@ -52,9 +53,11 @@ export default function ArticleCard({ news }: Props) {
       className="group block bg-gray-800 rounded-lg shadow-md overflow-hidden transition-all duration-200 transform hover:scale-[1.01] hover:bg-gray-700"
     >
       <div className="w-full h-44 overflow-hidden">
-        <img
+        <Image
           src={news.image || '/default-news.jpg'}
           alt={news.title}
+          width={400}
+          height={176}
           className="w-full h-full object-cover"
           loading="lazy"
         />

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -3,6 +3,7 @@
 
 import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
+import Image from 'next/image'
 
 type SourceLink = {
   name: string
@@ -66,12 +67,13 @@ function LogoImg({ slug, origin, label }: { slug: string; origin: string; label:
   }
 
   return (
-    <img
+    <Image
       src={candidates[idx]}
       alt={`${label} logo`}
+      width={28}
+      height={28}
       className="h-7 w-7 rounded-full bg-gray-700 object-cover"
       loading="lazy"
-      decoding="async"
       onError={() => setIdx(i => i + 1)}
     />
   )
@@ -106,7 +108,7 @@ export default function Footer() {
         {/* Leva kolona */}
         <div className="flex-1">
           <div className="flex items-center mb-4">
-            <img src="/logo.png" alt="Križišče" className="w-8 h-8 rounded-full mr-2" />
+            <Image src="/logo.png" alt="Križišče" width={32} height={32} className="w-8 h-8 rounded-full mr-2" />
             <h4 className="text-white font-semibold text-lg">Križišče</h4>
           </div>
           <p className="text-sm leading-relaxed">

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,6 +1,7 @@
 // components/Header.tsx
 
 import Link from 'next/link'
+import Image from 'next/image'
 
 export default function Header() {
   return (
@@ -9,9 +10,11 @@ export default function Header() {
         <div className="flex items-center space-x-3">
           <Link href="/">
             <div className="flex items-center space-x-3 cursor-pointer">
-              <img
+              <Image
                 src="/logo.png"
                 alt="Križišče"
+                width={32}
+                height={32}
                 className="w-8 h-8 rounded-full transition duration-300 transform hover:scale-105 hover:shadow-lg"
               />
               <div>


### PR DESCRIPTION
## Summary
- use Next.js Image component in article card, header, and footer
- ensure remote image domains are whitelisted via existing config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a432ba71cc83298ffb6786990c517d