### PR TITLE
Animate article grid with staggered layout transitions

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,7 @@ import React, {
   startTransition,
 } from 'react'
 import Link from 'next/link'
-import { motion, AnimatePresence } from 'framer-motion'
+import { motion, AnimatePresence, LayoutGroup } from 'framer-motion'
 
 import { NewsItem } from '@/types'
 import fetchRSSFeeds from '@/lib/fetchRSSFeeds'
@@ -261,18 +261,29 @@ export default function Home({ initialNews }: Props) {
           </p>
         ) : (
           <AnimatePresence mode="wait">
-            <motion.div
-              key={deferredFilter}
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -10 }}
-              transition={{ duration: 0.2 }}
-              className="grid gap-6 grid-cols-2 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-5"
-            >
-              {visibleNews.map((article, i) => (
-                <ArticleCard key={i} news={article} />
-              ))}
-            </motion.div>
+            <LayoutGroup>
+              <motion.div
+                key={deferredFilter}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -10 }}
+                transition={{ duration: 0.2, staggerChildren: 0.05 }}
+                className="grid gap-6 grid-cols-2 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-5"
+              >
+                {visibleNews.map((article, i) => (
+                  <motion.div
+                    key={i}
+                    layout
+                    transition={{ type: 'spring', damping: 20 }}
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -10 }}
+                  >
+                    <ArticleCard news={article} />
+                  </motion.div>
+                ))}
+              </motion.div>
+            </LayoutGroup>
           </AnimatePresence>
         )}
 


### PR DESCRIPTION
## Summary
- wrap news grid with `LayoutGroup` for coordinated layout animations
- animate each `ArticleCard` via `<motion.div layout>` and spring transition
- stagger card entrance to fade and slide sequentially on filter changes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive configuration prompt)*
- `npm run build -- --no-lint`

------
https://chatgpt.com/codex/tasks/task_e_68a43fc8e4248329adcad48cbeac4ace