### PR TITLE
feat: add light/dark theme toggle

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,11 +1,19 @@
 // components/Header.tsx
+"use client"
 
 import Link from 'next/link'
 import Image from 'next/image'
+import { useTheme } from 'next-themes'
+import { useEffect, useState } from 'react'
 
 export default function Header() {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => setMounted(true), [])
+  const isDark = theme === 'dark'
+
   return (
-    <header className="sticky top-0 z-40 bg-gray-900/70 backdrop-blur-md backdrop-saturate-150 py-2 border-b border-gray-800">
+    <header className="sticky top-0 z-40 bg-white/70 dark:bg-gray-900/70 backdrop-blur-md backdrop-saturate-150 py-2 border-b border-gray-200 dark:border-gray-800">
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 sm:gap-4 px-2 sm:px-4">
         <div className="flex items-center space-x-3">
           <Link href="/">
@@ -19,21 +27,34 @@ export default function Header() {
               />
               <div>
                 <h1 className="text-xl font-bold leading-tight">Križišče</h1>
-                <p className="text-xs text-gray-400">Najnovejše novice slovenskih medijev</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">Najnovejše novice slovenskih medijev</p>
               </div>
             </div>
           </Link>
         </div>
 
-        {/* Navigacija do drugih strani */}
-        <nav className="flex gap-4 text-sm">
-          <Link href="/projekt">
-            <a className="text-gray-400 hover:text-white transition">O projektu</a>
-          </Link>
-          <Link href="/pogoji">
-            <a className="text-gray-400 hover:text-white transition">Pogoji uporabe</a>
-          </Link>
-        </nav>
+        <div className="flex items-center gap-4">
+          {/* Navigacija do drugih strani */}
+          <nav className="flex gap-4 text-sm">
+            <Link href="/projekt">
+              <a className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition">O projektu</a>
+            </Link>
+            <Link href="/pogoji">
+              <a className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition">Pogoji uporabe</a>
+            </Link>
+          </nav>
+
+          {mounted && (
+            <button
+              type="button"
+              onClick={() => setTheme(isDark ? 'light' : 'dark')}
+              aria-pressed={isDark}
+              className="text-xl"
+            >
+              {isDark ? '🌞' : '🌜'}
+            </button>
+          )}
+        </div>
       </div>
     </header>
   )

--- a/package.json
+++ b/package.json
@@ -9,16 +9,17 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "framer-motion": "^11.0.0",
-    "next": "13.5.6",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "rss-parser": "^3.12.0",
+    "@supabase/supabase-js": "^2.39.5",
+    "@tailwindcss/line-clamp": "^0.4.4",
     "@vercel/analytics": "1.5.0",
     "@vercel/speed-insights": "1.2.0",
-    "@tailwindcss/line-clamp": "^0.4.4",
-    "@supabase/supabase-js": "^2.39.5",
-    "date-fns": "^3.6.0"
+    "date-fns": "^3.6.0",
+    "framer-motion": "^11.0.0",
+    "next": "13.5.6",
+    "next-themes": "^0.4.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "rss-parser": "^3.12.0"
   },
   "devDependencies": {
     "@types/node": "^20.6.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,6 +5,7 @@ import type { AppProps } from 'next/app'
 import { useEffect } from 'react'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
+import { ThemeProvider } from 'next-themes'
 
 // Uvoz Vercel Analytics in Speed Insights
 import { Analytics } from '@vercel/analytics/next'
@@ -60,7 +61,9 @@ function App({ Component, pageProps }: AppProps) {
       </Head>
 
       {/* Prikaz izbrane strani */}
-      <Component {...pageProps} />
+      <ThemeProvider attribute="class">
+        <Component {...pageProps} />
+      </ThemeProvider>
 
       {/* Vercel Analytics in Speed Insights */}
       <Analytics />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,21 +6,21 @@
    BARVNA PALETA / THEME VARIABLES
 ---------------------------------- */
 :root {
-  color-scheme: dark;
+  color-scheme: light;
 
   /* osnovne */
-  --bg: #0d0d0d;
-  --bg-soft: rgba(17, 17, 17, 0.8);
-  --text: #ffffff;
-  --text-dim: rgba(255,255,255,.68);
+  --bg: #fafafa;
+  --bg-soft: rgba(255,255,255,.85);
+  --text: #0f172a;
+  --text-dim: rgba(15,23,42,.7);
 
   /* obrobe / plastenje */
-  --ring: rgba(255,255,255,.12);
-  --divider: #232323;
+  --ring: rgba(15,23,42,.25);
+  --divider: #e5e7eb;
 
   /* brand (ujema se z bg-brand v Tailwind configu, če ga imaš) */
-  --brand: #ff9966;
-  --brand-hover: #ff8a4d;
+  --brand: #ff7a45;
+  --brand-hover: #ff6a2c;
 
   /* poudarki */
   --ok: #34d399;      /* emerald-400 */
@@ -28,9 +28,9 @@
   --err: #ef4444;     /* red-500 */
 
   /* sence/blur */
-  --card-bg: rgba(255,255,255,.05);
-  --card-bg-hover: rgba(255,255,255,.08);
-  --popover: rgba(13,13,13,.85);
+  --card-bg: rgba(0,0,0,.03);
+  --card-bg-hover: rgba(0,0,0,.06);
+  --popover: rgba(255,255,255,.96);
 }
 
 html, body { height: 100%; }
@@ -40,6 +40,7 @@ body {
   color: var(--text);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  transition: background-color .3s, color .3s;
 }
 
 /* ---------------------------------
@@ -128,23 +129,25 @@ body {
 }
 
 /* ---------------------------------
-   LAHKA TEMA (opcijsko)
-   Dodaj na <html> ali <body> razred .theme-light
+   LAHKA TEMA (privzeto)
+   Temni način z razredom .dark na <html> (next-themes)
 ---------------------------------- */
-.theme-light {
-  --bg: #fafafa;
-  --bg-soft: rgba(255,255,255,.85);
-  --text: #0f172a;
-  --text-dim: rgba(15,23,42,.7);
-  --ring: rgba(15,23,42,.25);
-  --divider: #e5e7eb;
+.dark {
+  color-scheme: dark;
 
-  --brand: #ff7a45;
-  --brand-hover: #ff6a2c;
+  --bg: #0d0d0d;
+  --bg-soft: rgba(17, 17, 17, 0.8);
+  --text: #ffffff;
+  --text-dim: rgba(255,255,255,.68);
+  --ring: rgba(255,255,255,.12);
+  --divider: #232323;
 
-  --card-bg: rgba(0,0,0,.03);
-  --card-bg-hover: rgba(0,0,0,.06);
-  --popover: rgba(255,255,255,.96);
+  --brand: #ff9966;
+  --brand-hover: #ff8a4d;
+
+  --card-bg: rgba(255,255,255,.05);
+  --card-bg-hover: rgba(255,255,255,.08);
+  --popover: rgba(13,13,13,.85);
 }
 
 /* ---------------------------------


### PR DESCRIPTION
## Summary
- install `next-themes` and wrap app with `ThemeProvider`
- add header button to switch between light and dark themes
- rework global styles for theme variables, add transitions, and remove old `.theme-light` class

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a4639ba3688329a03a1c834405b11b