### PR TITLE
style: adjust dark header border tone

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -13,7 +13,7 @@ export default function Header() {
   const isDark = theme === 'dark'
 
   return (
-    <header className="sticky top-0 z-40 bg-white/70 dark:bg-gray-900/70 backdrop-blur-md backdrop-saturate-150 py-2 border-b border-gray-200 dark:border-gray-800">
+    <header className="sticky top-0 z-40 bg-white/70 dark:bg-gray-900/70 backdrop-blur-md backdrop-saturate-150 py-2 border-b border-gray-200 dark:border-gray-700">
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 sm:gap-4 px-2 sm:px-4">
         <div className="flex items-center space-x-3">
           <Link href="/">


### PR DESCRIPTION
## Summary
- lighten dark mode header border to gray-700 for smoother integration with dark background

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a58b334b7883299bca1a6ff43373f1