### PR TITLE
style: adjust dark header border tone

### DIFF
--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -50,7 +50,7 @@ export default function ArticleCard({ news }: Props) {
       target="_blank"
       rel="noopener noreferrer"
       onClick={handleClick}
-      className="group block bg-gray-800 rounded-lg shadow-md overflow-hidden transition-all duration-200 transform hover:scale-[1.01] hover:bg-gray-700"
+      className="group block bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden transition-all duration-200 transform hover:scale-[1.01] hover:bg-gray-100 dark:hover:bg-gray-700"
     >
       <div className="relative w-full aspect-[16/9] overflow-hidden">
         <Image
@@ -63,7 +63,7 @@ export default function ArticleCard({ news }: Props) {
       </div>
 
       <div className="p-3">
-        <div className="flex justify-between text-xs text-gray-400 mb-1">
+        <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mb-1">
           <span
             className="font-medium text-[0.7rem]"
             style={{ color: sourceColor }}
@@ -74,14 +74,14 @@ export default function ArticleCard({ news }: Props) {
         </div>
 
         <h2
-          className="text-sm font-semibold leading-snug line-clamp-3 mb-1"
+          className="text-sm font-semibold leading-snug line-clamp-3 mb-1 text-gray-900 dark:text-white"
           title={news.title}
         >
           {news.title}
         </h2>
 
         {news.contentSnippet && (
-          <p className="text-gray-400 text-sm leading-tight line-clamp-4">
+          <p className="text-gray-600 dark:text-gray-400 text-sm leading-tight line-clamp-4">
             {news.contentSnippet}
           </p>
         )}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -13,7 +13,7 @@ export default function Header() {
   const isDark = theme === 'dark'
 
   return (
-    <header className="sticky top-0 z-40 bg-white/70 dark:bg-gray-900/70 backdrop-blur-md backdrop-saturate-150 py-2 border-b border-gray-200 dark:border-gray-800">
+    <header className="sticky top-0 z-40 bg-white/70 dark:bg-gray-900/70 backdrop-blur-md backdrop-saturate-150 py-2 border-b border-gray-200 dark:border-gray-700">
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 sm:gap-4 px-2 sm:px-4">
         <div className="flex items-center space-x-3">
           <Link href="/">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -123,14 +123,14 @@ export default function Home({ initialNews }: Props) {
   return (
     <>
       <Header />
-      <main className="min-h-screen bg-gray-900 text-white px-4 md:px-8 lg:px-16 py-8">
-        <div className="sticky top-0 z-40 bg-gray-900/70 backdrop-blur-md border-b border-gray-800 py-2 mb-6">
+      <main className="min-h-screen bg-white text-gray-900 dark:bg-gray-900 dark:text-white px-4 md:px-8 lg:px-16 py-8">
+        <div className="sticky top-0 z-40 bg-white/70 dark:bg-gray-900/70 backdrop-blur-md border-b border-gray-200 dark:border-gray-800 py-2 mb-6">
           <div className="flex items-center gap-2 w-full sm:w-auto sm:ml-auto px-2 sm:px-4">
             {showLeft && (
               <button
                 onClick={() => scrollBy(-220)}
                 aria-label="Premakni levo"
-                className="hidden sm:flex items-center justify-center p-2 text-gray-400 hover:text-white"
+                className="hidden sm:flex items-center justify-center p-2 text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -161,7 +161,7 @@ export default function Home({ initialNews }: Props) {
                   className={`relative px-3 py-1 rounded-full text-sm transition font-medium whitespace-nowrap ${
                     deferredFilter === source
                       ? 'text-white'
-                      : 'text-gray-400 hover:text-white'
+                      : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white'
                   }`}
                 >
                   {deferredFilter === source && (
@@ -180,7 +180,7 @@ export default function Home({ initialNews }: Props) {
               <button
                 onClick={() => scrollBy(220)}
                 aria-label="Premakni desno"
-                className="hidden sm:flex items-center justify-center p-2 text-gray-400 hover:text-white"
+                className="hidden sm:flex items-center justify-center p-2 text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -199,7 +199,7 @@ export default function Home({ initialNews }: Props) {
 
         {/* GRID */}
         {visibleNews.length === 0 ? (
-          <p className="text-gray-400 text-center w-full mt-10">
+          <p className="text-gray-500 dark:text-gray-400 text-center w-full mt-10">
             Ni novic za izbrani vir ali napaka pri nalaganju.
           </p>
         ) : (


### PR DESCRIPTION
## Summary
- lighten dark mode header border to gray-700 for smoother integration with dark background
- enable light theme backgrounds for article cards and homepage controls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a58b334b7883299bca1a6ff43373f1