### PR TITLE
style: theme-aware footer and translucent filters

### DIFF
--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -50,7 +50,7 @@ export default function ArticleCard({ news }: Props) {
       target="_blank"
       rel="noopener noreferrer"
       onClick={handleClick}
-      className="group block bg-gray-800 rounded-lg shadow-md overflow-hidden transition-all duration-200 transform hover:scale-[1.01] hover:bg-gray-700"
+      className="group block bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden transition-all duration-200 transform hover:scale-[1.01] hover:bg-gray-100 dark:hover:bg-gray-700"
     >
       <div className="relative w-full aspect-[16/9] overflow-hidden">
         <Image
@@ -63,7 +63,7 @@ export default function ArticleCard({ news }: Props) {
       </div>
 
       <div className="p-3">
-        <div className="flex justify-between text-xs text-gray-400 mb-1">
+        <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mb-1">
           <span
             className="font-medium text-[0.7rem]"
             style={{ color: sourceColor }}
@@ -74,14 +74,14 @@ export default function ArticleCard({ news }: Props) {
         </div>
 
         <h2
-          className="text-sm font-semibold leading-snug line-clamp-3 mb-1"
+          className="text-sm font-semibold leading-snug line-clamp-3 mb-1 text-gray-900 dark:text-white"
           title={news.title}
         >
           {news.title}
         </h2>
 
         {news.contentSnippet && (
-          <p className="text-gray-400 text-sm leading-tight line-clamp-4">
+          <p className="text-gray-600 dark:text-gray-400 text-sm leading-tight line-clamp-4">
             {news.contentSnippet}
           </p>
         )}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -60,7 +60,7 @@ function LogoImg({ slug, origin, label }: { slug: string; origin: string; label:
       .slice(0, 2)
       .join('')
     return (
-      <div className="h-7 w-7 grid place-items-center rounded-full bg-gray-700 text-[10px] font-semibold">
+      <div className="h-7 w-7 grid place-items-center rounded-full bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200 text-[10px] font-semibold">
         {initials || '•'}
       </div>
     )
@@ -72,7 +72,7 @@ function LogoImg({ slug, origin, label }: { slug: string; origin: string; label:
       alt={`${label} logo`}
       width={28}
       height={28}
-      className="h-7 w-7 rounded-full bg-gray-700 object-cover"
+      className="h-7 w-7 rounded-full bg-gray-200 dark:bg-gray-700 object-cover"
       loading="lazy"
       onError={() => setIdx(i => i + 1)}
     />
@@ -103,13 +103,13 @@ export default function Footer() {
   }, [open])
 
   return (
-    <footer className="relative bg-gray-900 text-gray-300 pt-12 pb-6 mt-8 border-t border-gray-800">
+    <footer className="relative pt-12 pb-6 mt-8 border-t bg-gray-50 text-gray-700 border-gray-200 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-800">
       <div className="max-w-6xl mx-auto px-4 flex flex-col sm:flex-row sm:justify-between sm:items-start gap-8">
         {/* Leva kolona */}
         <div className="flex-1">
           <div className="flex items-center mb-4">
             <Image src="/logo.png" alt="Križišče" width={32} height={32} className="w-8 h-8 rounded-full mr-2" />
-            <h4 className="text-white font-semibold text-lg">Križišče</h4>
+            <h4 className="text-gray-900 dark:text-white font-semibold text-lg">Križišče</h4>
           </div>
           <p className="text-sm leading-relaxed">
             Agregator najnovejših novic slovenskih medijev. <br />
@@ -117,23 +117,23 @@ export default function Footer() {
           </p>
         </div>
 
-        <div className="hidden sm:block w-px bg-gray-800" />
+        <div className="hidden sm:block w-px bg-gray-200 dark:bg-gray-800" />
 
         {/* Srednja kolona */}
         <div className="flex-1">
-          <h4 className="text-white font-semibold mb-4">Povezave</h4>
+          <h4 className="text-gray-900 dark:text-white font-semibold mb-4">Povezave</h4>
           <ul className="space-y-2 text-sm">
-            <li><Link href="/projekt" className="hover:text-white transition">O projektu</Link></li>
-            <li><Link href="/pogoji" className="hover:text-white transition">Pogoji uporabe</Link></li>
+            <li><Link href="/projekt" className="text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white transition">O projektu</Link></li>
+            <li><Link href="/pogoji" className="text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white transition">Pogoji uporabe</Link></li>
           </ul>
         </div>
 
-        <div className="hidden sm:block w-px bg-gray-800" />
+        <div className="hidden sm:block w-px bg-gray-200 dark:bg-gray-800" />
 
         {/* Desna kolona */}
         <div className="flex-1">
-          <h4 className="text-white font-semibold mb-4">Kontakt</h4>
-          <a href="mailto:gjkcme@gmail.com" className="text-sm hover:text-white transition">
+          <h4 className="text-gray-900 dark:text-white font-semibold mb-4">Kontakt</h4>
+          <a href="mailto:gjkcme@gmail.com" className="text-sm text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white transition">
             Pošljite nam sporočilo
           </a>
         </div>
@@ -146,8 +146,9 @@ export default function Footer() {
             ref={btnRef}
             type="button"
             onClick={() => setOpen(v => !v)}
-            className="inline-flex items-center gap-2 rounded-full px-4 py-2 ring-1 ring-white/10
-                       text-gray-300 hover:text-white bg-gray-800/30 hover:bg-gray-800/50 transition"
+            className="inline-flex items-center gap-2 rounded-full px-4 py-2 ring-1 ring-gray-200/50 dark:ring-white/10
+                       text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white
+                       bg-white/30 hover:bg-white/50 dark:bg-gray-800/30 dark:hover:bg-gray-800/50 backdrop-blur-sm transition"
             aria-haspopup="dialog"
             aria-expanded={open}
           >
@@ -159,8 +160,8 @@ export default function Footer() {
             <div
               ref={popRef}
               className="absolute left-1/2 -translate-x-1/2 bottom-full mb-4
-                         w-[min(92vw,64rem)] rounded-2xl bg-gray-900/85 backdrop-blur
-                         ring-1 ring-white/10 shadow-2xl p-4 sm:p-6 animate-popoverFade"
+                         w-[min(92vw,64rem)] rounded-2xl bg-white/90 dark:bg-gray-900/85 backdrop-blur
+                         ring-1 ring-gray-200/50 dark:ring-white/10 shadow-2xl p-4 sm:p-6 animate-popoverFade"
               role="dialog"
               aria-label="Viri novic"
             >
@@ -176,8 +177,8 @@ export default function Footer() {
                       href={it.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="flex items-center gap-2 px-2 py-2 rounded-lg text-gray-300
-                                 hover:text-white hover:bg-gray-800/60 transition"
+                      className="flex items-center gap-2 px-2 py-2 rounded-lg text-gray-700 dark:text-gray-300
+                                 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100/60 dark:hover:bg-gray-800/60 transition"
                     >
                       <LogoImg slug={it.slug} origin={origin} label={it.name} />
                       <span className="text-sm">{it.name}</span>
@@ -191,7 +192,7 @@ export default function Footer() {
         </div>
       </div>
 
-      <div className="border-t border-gray-800 mt-12 pt-4 text-center text-sm text-gray-500">
+      <div className="border-t border-gray-200 dark:border-gray-800 mt-12 pt-4 text-center text-sm text-gray-500">
         <p className="italic mb-2">“Informacija ni znanje. Edino razumevanje šteje.” – Albert Einstein</p>
         <p>© {year} Križišče – Vse pravice pridržane.</p>
       </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -13,7 +13,7 @@ export default function Header() {
   const isDark = theme === 'dark'
 
   return (
-    <header className="sticky top-0 z-40 bg-white/70 dark:bg-gray-900/70 backdrop-blur-md backdrop-saturate-150 py-2 border-b border-gray-200 dark:border-gray-800">
+    <header className="sticky top-0 z-40 bg-gray-50/80 dark:bg-gray-900/70 backdrop-blur-md backdrop-saturate-150 py-2 border-b border-gray-200 dark:border-gray-700">
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 sm:gap-4 px-2 sm:px-4">
         <div className="flex items-center space-x-3">
           <Link href="/">

--- a/components/SourcesMenu.tsx
+++ b/components/SourcesMenu.tsx
@@ -43,7 +43,7 @@ export default function SourcesMenu({ items, className = "" }: Props) {
         aria-expanded={open}
         aria-label="Viri novic"
         onClick={() => setOpen((v) => !v)}
-        className="relative h-9 w-9 rounded-full bg-gray-800/70 ring-1 ring-white/10 hover:bg-gray-700 text-white grid place-items-center transition"
+        className="relative h-9 w-9 rounded-full bg-white/40 dark:bg-gray-800/70 ring-1 ring-gray-200/50 dark:ring-white/10 hover:bg-white/60 dark:hover:bg-gray-700 text-gray-700 dark:text-white grid place-items-center transition backdrop-blur-sm"
       >
         {/* 3 krogci v orbiti – nežna animacija */}
         <span className="relative block h-5 w-5">
@@ -61,9 +61,9 @@ export default function SourcesMenu({ items, className = "" }: Props) {
           ref={menuRef}
           role="menu"
           tabIndex={-1}
-          className="absolute right-0 mt-2 w-64 max-h-80 overflow-auto rounded-xl bg-gray-850/95 backdrop-blur shadow-xl ring-1 ring-white/10 p-2 z-50"
+          className="absolute right-0 mt-2 w-64 max-h-80 overflow-auto rounded-xl bg-white/80 dark:bg-gray-850/95 backdrop-blur shadow-xl ring-1 ring-gray-200/50 dark:ring-white/10 p-2 z-50"
         >
-          <p className="px-2 pb-2 text-xs uppercase tracking-wide text-gray-400">
+          <p className="px-2 pb-2 text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
             Viri novic
           </p>
           <div className="grid gap-1">
@@ -73,9 +73,9 @@ export default function SourcesMenu({ items, className = "" }: Props) {
                 href={it.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-gray-750 text-gray-200"
+                className="flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-750 text-gray-700 dark:text-gray-200"
               >
-                <span className="grid h-6 w-6 place-items-center rounded-full bg-gray-700 text-[10px] font-bold">
+                <span className="grid h-6 w-6 place-items-center rounded-full bg-gray-300 text-gray-700 dark:bg-gray-700 dark:text-gray-200 text-[10px] font-bold">
                   {it.name.slice(0, 2)}
                 </span>
                 <span className="text-sm">{it.name}</span>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -123,14 +123,14 @@ export default function Home({ initialNews }: Props) {
   return (
     <>
       <Header />
-      <main className="min-h-screen bg-gray-900 text-white px-4 md:px-8 lg:px-16 py-8">
-        <div className="sticky top-0 z-40 bg-gray-900/70 backdrop-blur-md border-b border-gray-800 py-2 mb-6">
+      <main className="min-h-screen bg-white text-gray-900 dark:bg-gray-900 dark:text-white px-4 md:px-8 lg:px-16 py-8">
+        <div className="sticky top-0 z-40 backdrop-blur-md bg-white/40 dark:bg-gray-900/40 ring-1 ring-gray-200/50 dark:ring-gray-700/50 py-2 mb-6">
           <div className="flex items-center gap-2 w-full sm:w-auto sm:ml-auto px-2 sm:px-4">
             {showLeft && (
               <button
                 onClick={() => scrollBy(-220)}
                 aria-label="Premakni levo"
-                className="hidden sm:flex items-center justify-center p-2 text-gray-400 hover:text-white"
+                className="hidden sm:flex items-center justify-center p-2 text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -161,7 +161,7 @@ export default function Home({ initialNews }: Props) {
                   className={`relative px-3 py-1 rounded-full text-sm transition font-medium whitespace-nowrap ${
                     deferredFilter === source
                       ? 'text-white'
-                      : 'text-gray-400 hover:text-white'
+                      : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white'
                   }`}
                 >
                   {deferredFilter === source && (
@@ -180,7 +180,7 @@ export default function Home({ initialNews }: Props) {
               <button
                 onClick={() => scrollBy(220)}
                 aria-label="Premakni desno"
-                className="hidden sm:flex items-center justify-center p-2 text-gray-400 hover:text-white"
+                className="hidden sm:flex items-center justify-center p-2 text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -199,7 +199,7 @@ export default function Home({ initialNews }: Props) {
 
         {/* GRID */}
         {visibleNews.length === 0 ? (
-          <p className="text-gray-400 text-center w-full mt-10">
+          <p className="text-gray-500 dark:text-gray-400 text-center w-full mt-10">
             Ni novic za izbrani vir ali napaka pri nalaganju.
           </p>
         ) : (


### PR DESCRIPTION
## Summary
- soften light-mode header background for improved aesthetics
- add light/dark adaptive styling to footer and source popover
- modernize source filters with translucent, theme-aware controls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a58b334b7883299bca1a6ff43373f1