### PR TITLE
Add article preview modal with sanitized content

### DIFF
--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -2,12 +2,15 @@ import { NewsItem } from '@/types'
 import { format } from 'date-fns'
 import { sl } from 'date-fns/locale'
 import { sourceColors } from '@/lib/sources'
-import { MouseEvent } from 'react'
+import { MouseEvent, useState } from 'react'
 import Image from 'next/image'
+import dynamic from 'next/dynamic'
 
 interface Props {
   news: NewsItem
 }
+
+const ArticlePreview = dynamic(() => import('./ArticlePreview'), { ssr: false })
 
 export default function ArticleCard({ news }: Props) {
   const formattedDate = format(new Date(news.isoDate), 'd. MMM, HH:mm', {
@@ -15,6 +18,8 @@ export default function ArticleCard({ news }: Props) {
   })
 
   const sourceColor = sourceColors[news.source] || '#fc9c6c'
+
+  const [showPreview, setShowPreview] = useState(false)
 
   const handleClick = async (e: MouseEvent<HTMLAnchorElement>) => {
     // Ignoriraj srednji klik in Ctrl/Cmd + klik (brskalnik sam odpre v novem zavihku)
@@ -60,6 +65,29 @@ export default function ArticleCard({ news }: Props) {
           className="object-cover"
           loading="lazy"
         />
+        <button
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            setShowPreview(true)
+          }}
+          aria-label="Prikaži predogled"
+          className="absolute top-2 right-2 p-2 bg-white/80 hover:bg-white rounded-full text-gray-700 hover:text-gray-900"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="w-4 h-4"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <line x1="21" y1="21" x2="16.65" y2="16.65" />
+          </svg>
+        </button>
       </div>
 
       <div className="p-3">
@@ -86,6 +114,9 @@ export default function ArticleCard({ news }: Props) {
           </p>
         )}
       </div>
+      {showPreview && (
+        <ArticlePreview url={news.link} onClose={() => setShowPreview(false)} />
+      )}
     </a>
   )
 }

--- a/components/ArticlePreview.tsx
+++ b/components/ArticlePreview.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef, useState } from 'react'
+import DOMPurify from 'dompurify'
+
+interface Props {
+  url: string
+  onClose: () => void
+}
+
+export default function ArticlePreview({ url, onClose }: Props) {
+  const [content, setContent] = useState('')
+  const modalRef = useRef<HTMLDivElement>(null)
+  const closeRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    const fetchContent = async () => {
+      try {
+        const res = await fetch(`/api/preview?url=${encodeURIComponent(url)}`)
+        const data = await res.json()
+        setContent(DOMPurify.sanitize(data.html))
+      } catch (err) {
+        setContent('<p>Napaka pri nalaganju predogleda.</p>')
+      }
+    }
+    fetchContent()
+  }, [url])
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose()
+      } else if (e.key === 'Tab') {
+        const focusable = modalRef.current?.querySelectorAll<HTMLElement>(
+          'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])'
+        )
+        if (!focusable || focusable.length === 0) return
+        const first = focusable[0]
+        const last = focusable[focusable.length - 1]
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault()
+            last.focus()
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault()
+            first.focus()
+          }
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    closeRef.current?.focus()
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      document.body.style.overflow = prevOverflow
+    }
+  }, [onClose])
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" role="dialog" aria-modal="true">
+      <div
+        ref={modalRef}
+        className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-4 max-w-3xl w-full mx-4 max-h-screen overflow-y-auto"
+      >
+        <button
+          ref={closeRef}
+          onClick={onClose}
+          aria-label="Zapri predogled"
+          className="mb-4 inline-flex items-center justify-center text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="w-4 h-4"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <line x1="21" y1="21" x2="16.65" y2="16.65" />
+          </svg>
+        </button>
+        <div dangerouslySetInnerHTML={{ __html: content }} />
+      </div>
+    </div>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@vercel/analytics": "1.5.0",
     "@vercel/speed-insights": "1.2.0",
     "date-fns": "^3.6.0",
+    "dompurify": "^3.2.6",
     "framer-motion": "^11.0.0",
     "next": "13.5.6",
     "next-themes": "^0.4.6",

--- a/pages/api/preview.ts
+++ b/pages/api/preview.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { url } = req.query
+  if (!url || typeof url !== 'string') {
+    res.status(400).json({ error: 'Missing url parameter' })
+    return
+  }
+  try {
+    const response = await fetch(url)
+    if (!response.ok) {
+      res.status(500).json({ error: 'Failed to fetch url' })
+      return
+    }
+    const html = await response.text()
+    res.status(200).json({ html })
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch preview' })
+  }
+}


### PR DESCRIPTION
## Summary
- add preview button to article card which loads a modal with the article content
- dynamically load ArticlePreview modal and sanitize HTML via DOMPurify
- introduce `/api/preview` endpoint for fetching article HTML

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ba7e29608329b6cf54c30cbf63ca