### PR TITLE
feat(api): set user agent for preview fetch

### DIFF
--- a/pages/api/preview.ts
+++ b/pages/api/preview.ts
@@ -7,9 +7,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return
   }
   try {
-    const response = await fetch(url)
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept-Language': 'en-US,en;q=0.9',
+      },
+    })
     if (!response.ok) {
-      res.status(500).json({ error: 'Failed to fetch url' })
+      res.status(500).json({ error: 'Failed to fetch preview' })
       return
     }
     const html = await response.text()


### PR DESCRIPTION
## Summary
- send standard browser headers when fetching preview content
- surface JSON error when preview fetch fails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Requires ESLint configuration input)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c0d36214832982299c7ad634428d