### PR TITLE
Use portal for article preview overlay

### DIFF
--- a/components/ArticlePreview.tsx
+++ b/components/ArticlePreview.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import DOMPurify from 'dompurify'
 
 interface Props {
@@ -59,7 +60,9 @@ export default function ArticlePreview({ url, onClose }: Props) {
     }
   }, [onClose])
 
-  return (
+  if (typeof document === 'undefined') return null
+
+  return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" role="dialog" aria-modal="true">
       <div
         ref={modalRef}
@@ -87,6 +90,7 @@ export default function ArticlePreview({ url, onClose }: Props) {
         </button>
         <div dangerouslySetInnerHTML={{ __html: content }} />
       </div>
-    </div>
+    </div>,
+    document.body
   )
 }


### PR DESCRIPTION
## Summary
- render article preview modal via `createPortal` attached to `document.body`
- ensure modal overlay covers viewport while preserving focus-trap behavior

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c2915d908329ac0a531d54980a35